### PR TITLE
bugfix: add nil check avoid panic

### DIFF
--- a/conditions.go
+++ b/conditions.go
@@ -66,6 +66,9 @@ func (c *SOrConditions) WhereClause() string {
 func AND(cond ...ICondition) ICondition {
 	conds := make([]ICondition, 0)
 	for _, c := range cond {
+		if c == nil {
+			continue
+		}
 		andCond, ok := c.(*SAndConditions)
 		if ok {
 			conds = append(conds, andCond.conditions...)
@@ -73,6 +76,11 @@ func AND(cond ...ICondition) ICondition {
 			conds = append(conds, c)
 		}
 	}
+
+	if len(conds) == 0 {
+		return nil
+	}
+
 	cc := SAndConditions{SCompoundConditions{conditions: conds}}
 	return &cc
 }
@@ -80,6 +88,9 @@ func AND(cond ...ICondition) ICondition {
 func OR(cond ...ICondition) ICondition {
 	conds := make([]ICondition, 0)
 	for _, c := range cond {
+		if c == nil {
+			continue
+		}
 		orCond, ok := c.(*SOrConditions)
 		if ok {
 			conds = append(conds, orCond.conditions...)
@@ -87,6 +98,11 @@ func OR(cond ...ICondition) ICondition {
 			conds = append(conds, c)
 		}
 	}
+
+	if len(conds) == 0 {
+		return nil
+	}
+
 	cc := SOrConditions{SCompoundConditions{conditions: conds}}
 	return &cc
 }
@@ -104,6 +120,9 @@ func (c *SNotCondition) Variables() []interface{} {
 }
 
 func NOT(cond ICondition) ICondition {
+	if cond == nil {
+		return nil
+	}
 	cc := SNotCondition{condition: cond}
 	return &cc
 }
@@ -129,6 +148,9 @@ func (c *SIsNullCondition) WhereClause() string {
 }
 
 func IsNull(f IQueryField) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SIsNullCondition{NewSingleCondition(f)}
 	return &c
 }
@@ -142,6 +164,9 @@ func (c *SIsNotNullCondition) WhereClause() string {
 }
 
 func IsNotNull(f IQueryField) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SIsNotNullCondition{NewSingleCondition(f)}
 	return &c
 }
@@ -155,6 +180,9 @@ func (c *SIsEmptyCondition) WhereClause() string {
 }
 
 func IsEmpty(f IQueryField) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SIsEmptyCondition{NewSingleCondition(f)}
 	return &c
 }
@@ -168,6 +196,9 @@ func (c *SIsNullOrEmptyCondition) WhereClause() string {
 }
 
 func IsNullOrEmpty(f IQueryField) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SIsNullOrEmptyCondition{NewSingleCondition(f)}
 	return &c
 }
@@ -181,6 +212,9 @@ func (c *SIsNotEmptyCondition) WhereClause() string {
 }
 
 func IsNotEmpty(f IQueryField) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SIsNotEmptyCondition{NewSingleCondition(f)}
 	return &c
 }
@@ -194,6 +228,9 @@ func (c *SIsTrueCondition) WhereClause() string {
 }
 
 func IsTrue(f IQueryField) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SIsTrueCondition{NewSingleCondition(f)}
 	return &c
 }
@@ -207,6 +244,9 @@ func (c *SIsFalseCondition) WhereClause() string {
 }
 
 func IsFalse(f IQueryField) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SIsFalseCondition{NewSingleCondition(f)}
 	return &c
 }
@@ -305,11 +345,17 @@ func (t *SInCondition) WhereClause() string {
 }
 
 func In(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SInCondition{NewTupleCondition(f, v)}
 	return &c
 }
 
 func NotIn(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	return NOT(In(f, v))
 }
 
@@ -333,23 +379,35 @@ func (t *SLikeCondition) WhereClause() string {
 }
 
 func Like(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SLikeCondition{NewTupleCondition(f, v)}
 	return &c
 }
 
 func Contains(f IQueryField, v string) ICondition {
+	if f == nil {
+		return nil
+	}
 	v = likeEscape(v)
 	nv := fmt.Sprintf("%%%s%%", v)
 	return Like(f, nv)
 }
 
 func Startswith(f IQueryField, v string) ICondition {
+	if f == nil {
+		return nil
+	}
 	v = likeEscape(v)
 	nv := fmt.Sprintf("%s%%", v)
 	return Like(f, nv)
 }
 
 func Endswith(f IQueryField, v string) ICondition {
+	if f == nil {
+		return nil
+	}
 	v = likeEscape(v)
 	nv := fmt.Sprintf("%%%s", v)
 	return Like(f, nv)
@@ -364,6 +422,9 @@ func (t *SEqualsCondition) WhereClause() string {
 }
 
 func Equals(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SEqualsCondition{NewTupleCondition(f, v)}
 	return &c
 }
@@ -377,6 +438,9 @@ func (t *SNotEqualsCondition) WhereClause() string {
 }
 
 func NotEquals(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SNotEqualsCondition{NewTupleCondition(f, v)}
 	return &c
 }
@@ -390,6 +454,9 @@ func (t *SGreatEqualCondition) WhereClause() string {
 }
 
 func GE(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SGreatEqualCondition{NewTupleCondition(f, v)}
 	return &c
 }
@@ -403,6 +470,9 @@ func (t *SGreatThanCondition) WhereClause() string {
 }
 
 func GT(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SGreatThanCondition{NewTupleCondition(f, v)}
 	return &c
 }
@@ -416,6 +486,9 @@ func (t *SLessEqualCondition) WhereClause() string {
 }
 
 func LE(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SLessEqualCondition{NewTupleCondition(f, v)}
 	return &c
 }
@@ -429,6 +502,9 @@ func (t *SLessThanCondition) WhereClause() string {
 }
 
 func LT(f IQueryField, v interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SLessThanCondition{NewTupleCondition(f, v)}
 	return &c
 }
@@ -462,6 +538,9 @@ func (t *SBetweenCondition) WhereClause() string {
 }
 
 func Between(f IQueryField, r1, r2 interface{}) ICondition {
+	if f == nil {
+		return nil
+	}
 	c := SBetweenCondition{NewTripleCondition(f, r1, r2)}
 	return &c
 }

--- a/filter.go
+++ b/filter.go
@@ -18,111 +18,199 @@ func (tq *SQuery) Filter(cond ICondition) *SQuery {
 }
 
 func (q *SQuery) Like(f string, v interface{}) *SQuery {
-	cond := Like(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Like(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) Contains(f string, v string) *SQuery {
-	cond := Contains(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Contains(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) Startswith(f string, v string) *SQuery {
-	cond := Startswith(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Startswith(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) Endswith(f string, v string) *SQuery {
-	cond := Endswith(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Endswith(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) NotLike(f string, v interface{}) *SQuery {
-	cond := Like(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Like(field, v)
 	return q.Filter(NOT(cond))
 }
 
 func (q *SQuery) In(f string, v interface{}) *SQuery {
-	cond := In(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := In(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) NotIn(f string, v interface{}) *SQuery {
-	cond := In(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := In(field, v)
 	return q.Filter(NOT(cond))
 }
 
 func (q *SQuery) Between(f string, v1, v2 interface{}) *SQuery {
-	cond := Between(q.Field(f), v1, v2)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Between(field, v1, v2)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) NotBetween(f string, v1, v2 interface{}) *SQuery {
-	cond := Between(q.Field(f), v1, v2)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Between(field, v1, v2)
 	return q.Filter(NOT(cond))
 }
 
 func (q *SQuery) Equals(f string, v interface{}) *SQuery {
-	cond := Equals(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := Equals(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) NotEquals(f string, v interface{}) *SQuery {
-	cond := NotEquals(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := NotEquals(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) GE(f string, v interface{}) *SQuery {
-	cond := GE(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := GE(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) LE(f string, v interface{}) *SQuery {
-	cond := LE(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := LE(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) GT(f string, v interface{}) *SQuery {
-	cond := GT(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := GT(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) LT(f string, v interface{}) *SQuery {
-	cond := LT(q.Field(f), v)
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := LT(field, v)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) IsNull(f string) *SQuery {
-	cond := IsNull(q.Field(f))
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := IsNull(field)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) IsNotNull(f string) *SQuery {
-	cond := IsNotNull(q.Field(f))
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := IsNotNull(field)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) IsEmpty(f string) *SQuery {
-	cond := IsEmpty(q.Field(f))
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := IsEmpty(field)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) IsNullOrEmpty(f string) *SQuery {
-	cond := IsNullOrEmpty(q.Field(f))
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := IsNullOrEmpty(field)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) IsNotEmpty(f string) *SQuery {
-	cond := IsNotEmpty(q.Field(f))
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := IsNotEmpty(field)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) IsTrue(f string) *SQuery {
-	cond := IsTrue(q.Field(f))
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := IsTrue(field)
 	return q.Filter(cond)
 }
 
 func (q *SQuery) IsFalse(f string) *SQuery {
-	cond := IsFalse(q.Field(f))
+	field := q.Field(f)
+	if field == nil {
+		return q
+	}
+	cond := IsFalse(field)
 	return q.Filter(cond)
 }

--- a/query.go
+++ b/query.go
@@ -277,8 +277,10 @@ func queryString(tq *SQuery) string {
 		buf.WriteString(string(join.jointype))
 		buf.WriteByte(' ')
 		buf.WriteString(fmt.Sprintf("%s AS `%s`", join.from.Expression(), join.from.Alias()))
-		buf.WriteString(" ON ")
-		buf.WriteString(join.condition.WhereClause())
+		if join.condition != nil {
+			buf.WriteString(" ON ")
+			buf.WriteString(join.condition.WhereClause())
+		}
 	}
 	if tq.where != nil {
 		buf.WriteString(" WHERE ")
@@ -312,14 +314,23 @@ func queryString(tq *SQuery) string {
 }
 
 func (tq *SQuery) Join(from IQuerySource, on ICondition) *SQuery {
+	if from == nil {
+		return tq
+	}
 	return tq._join(from, on, INNERJOIN)
 }
 
 func (tq *SQuery) LeftJoin(from IQuerySource, on ICondition) *SQuery {
+	if from == nil {
+		return tq
+	}
 	return tq._join(from, on, LEFTJOIN)
 }
 
 func (tq *SQuery) RightJoin(from IQuerySource, on ICondition) *SQuery {
+	if from == nil {
+		return tq
+	}
 	return tq._join(from, on, RIGHTJOIN)
 }
 
@@ -346,8 +357,10 @@ func (tq *SQuery) Variables() []interface{} {
 	for _, join := range tq.joins {
 		fromvars = join.from.Variables()
 		vars = append(vars, fromvars...)
-		fromvars = join.condition.Variables()
-		vars = append(vars, fromvars...)
+		if join.condition != nil {
+			fromvars = join.condition.Variables()
+			vars = append(vars, fromvars...)
+		}
 	}
 	if tq.where != nil {
 		fromvars = tq.where.Variables()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: add nil check avoid panic

```
[E 190425 15:56:29 appsrv.execCallback.func1(workers.go:199)] WorkerManager exec callback error: runtime error: invalid memory address or nil pointer dereference
goroutine 18044 [running]:
runtime/debug.Stack(0x19, 0xc420f8d070, 0x1)
        /usr/local/go/src/runtime/debug/stack.go:24 +0xa7
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:16 +0x22
yunion.io/x/onecloud/pkg/appsrv.execCallback.func1(0xc4208a5580)
        /home/yunion/go/src/yunion.io/x/onecloud/pkg/appsrv/workers.go:203 +0xac
panic(0x1b7d6c0, 0x3434cb0)
        /usr/local/go/src/runtime/panic.go:502 +0x229
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.tupleConditionWhereClause(0xc420dbc7c0, 0x1fc6c4b, 0x2, 0x1, 0x40)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/conditions.go:221 +0x47
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.(*SNotEqualsCondition).WhereClause(0xc420dbc7c0, 0x1fc7028, 0x0)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/conditions.go:376 +0x42
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.compoundWhereClause(0xc420dbc800, 0x1fc70e6, 0x3, 0x7, 0x7)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/conditions.go:29 +0x72
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.(*SAndConditions).WhereClause(0xc420dbc800, 0x1fcb2ca, 0x7)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/conditions.go:55 +0x42
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.queryString(0xc420f8d6f8, 0x411a59, 0xc420cb9330)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/query.go:285 +0xa93
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.(*SQuery).String(0xc420f8d6f8, 0x0, 0x100000000000000)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/query.go:252 +0x2b
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.(*SQuery).Row(0xc420f8d6f8, 0xc420de64e0)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/query.go:370 +0x40
yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy.(*SQuery).CountWithError(0xc4209f2180, 0x1fcc252, 0x7, 0x1a44d00)
        /home/yunion/go/src/yunion.io/x/onecloud/vendor/yunion.io/x/sqlchemy/query.go:400 +0x1c2
yunion.io/x/onecloud/pkg/compute/models.inputUniquenessCheck(0xc42000e1b8, 0xc420437020, 0x24, 0xc420436ff0, 0x24, 0x21cbaa0, 0xc4205631a0, 0xc420f85a50)
        /home/yunion/go/src/yunion.io/x/onecloud/pkg/compute/models/hosts.go:2455 +0x714
yunion.io/x/onecloud/pkg/compute/models.(*SHost).ValidateUpdateData(0xc42009e580, 0x21df7c0, 0xc4208fd200, 0x21f97c0, 0xc420c672f0, 0x21fa9c0, 0xc42000e1a8, 0xc42000e1b8, 0xc420940888, 0xc4208fd200, ...)
        /home/yunion/go/src/yunion.io/x/onecloud/pkg/compute/models/hosts.go:2518 +0x72
```