### PR TITLE
feature: optmize query fuctions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# ---> Go
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+*.swp
+*.exe
+*.test
+*.prof
+_output
+/relay
+/structargtest
+.idea
+GPATH
+GRTAGS
+GTAGS

--- a/filter.go
+++ b/filter.go
@@ -14,129 +14,186 @@
 
 package sqlchemy
 
+// filter is where condition
 func (tq *SQuery) Filter(cond ICondition) *SQuery {
-	if tq.groupBy != nil && len(tq.groupBy) > 0 {
-		if tq.having == nil {
-			tq.having = cond
-		} else {
-			tq.having = AND(tq.having, cond)
-		}
+	if tq.filterConds == nil {
+		tq.filterConds = make([]ICondition, 0)
+	}
+	tq.filterConds = append(tq.filterConds, cond)
+	return tq
+}
+
+func (tq *SQuery) Having(cond ICondition) *SQuery {
+	if tq.having == nil {
+		tq.having = cond
 	} else {
-		if tq.where == nil {
-			tq.where = cond
-		} else {
-			tq.where = AND(tq.where, cond)
-		}
+		tq.having = AND(tq.having, cond)
 	}
 	return tq
 }
 
 func (q *SQuery) Like(f string, v interface{}) *SQuery {
 	cond := Like(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) Contains(f string, v string) *SQuery {
 	cond := Contains(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) Startswith(f string, v string) *SQuery {
 	cond := Startswith(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) Endswith(f string, v string) *SQuery {
 	cond := Endswith(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) NotLike(f string, v interface{}) *SQuery {
-	cond := Like(q.Field(f), v)
-	return q.Filter(NOT(cond))
+	cond := NOT(Like(q.Field(f), v))
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) In(f string, v interface{}) *SQuery {
 	cond := In(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) NotIn(f string, v interface{}) *SQuery {
-	cond := In(q.Field(f), v)
-	return q.Filter(NOT(cond))
+	cond := NOT(In(q.Field(f), v))
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
+}
+
+func (q *SQuery) OR(qs ...*SQuery) *SQuery {
+	conds := make([]ICondition, 0)
+	for i := 0; i < len(qs); i++ {
+		if qs[i].lastConds != nil {
+			conds = append(conds, qs[i].lastConds)
+		}
+		qs[i].filterConds = qs[i].filterConds[:len(qs[i].filterConds)-1]
+		qs[i].lastConds = nil
+	}
+	cond := OR(conds...)
+	q.Filter(cond)
+	return &SQuery{
+		sQuery:    q.sQuery,
+		lastConds: cond,
+	}
+}
+
+func (q *SQuery) AND(qs ...*SQuery) *SQuery {
+	conds := make([]ICondition, 0)
+	for i := 0; i < len(qs); i++ {
+		if qs[i].lastConds != nil {
+			conds = append(conds, qs[i].lastConds)
+		}
+		qs[i].filterConds = qs[i].filterConds[:len(qs[i].filterConds)-1]
+		qs[i].lastConds = nil
+	}
+	cond := AND(conds...)
+	q.Filter(cond)
+	return &SQuery{
+		sQuery:    q.sQuery,
+		lastConds: cond,
+	}
 }
 
 func (q *SQuery) Between(f string, v1, v2 interface{}) *SQuery {
 	cond := Between(q.Field(f), v1, v2)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) NotBetween(f string, v1, v2 interface{}) *SQuery {
-	cond := Between(q.Field(f), v1, v2)
-	return q.Filter(NOT(cond))
+	cond := NOT(Between(q.Field(f), v1, v2))
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) Equals(f string, v interface{}) *SQuery {
 	cond := Equals(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) NotEquals(f string, v interface{}) *SQuery {
 	cond := NotEquals(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) GE(f string, v interface{}) *SQuery {
 	cond := GE(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) LE(f string, v interface{}) *SQuery {
 	cond := LE(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) GT(f string, v interface{}) *SQuery {
 	cond := GT(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) LT(f string, v interface{}) *SQuery {
 	cond := LT(q.Field(f), v)
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) IsNull(f string) *SQuery {
 	cond := IsNull(q.Field(f))
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) IsNotNull(f string) *SQuery {
 	cond := IsNotNull(q.Field(f))
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) IsEmpty(f string) *SQuery {
 	cond := IsEmpty(q.Field(f))
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) IsNullOrEmpty(f string) *SQuery {
 	cond := IsNullOrEmpty(q.Field(f))
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) IsNotEmpty(f string) *SQuery {
 	cond := IsNotEmpty(q.Field(f))
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) IsTrue(f string) *SQuery {
 	cond := IsTrue(q.Field(f))
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }
 
 func (q *SQuery) IsFalse(f string) *SQuery {
 	cond := IsFalse(q.Field(f))
-	return q.Filter(cond)
+	q.Filter(cond)
+	return &SQuery{q.sQuery, cond}
 }

--- a/rawquery.go
+++ b/rawquery.go
@@ -40,6 +40,6 @@ func NewRawQuery(sqlStr string, fields ...string) *SQuery {
 		rqf := SRawQueryField{name: f}
 		qfs[i] = &rqf
 	}
-	q := SQuery{rawSql: sqlStr, fields: qfs}
+	q := SQuery{sQuery: &sQuery{rawSql: sqlStr, fields: qfs}}
 	return &q
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
- 优化query函数的写法，让sql拼接更简短，易读.
    具体的就是之前的写法, 类似这种： `q.Filter(sqlchemy.OR(sqlchemy.Equals(), sqlchemy.In()))`   变成这种：`q.OR(q.Equals(), q.In())`

## 具体用法 

比如之前的一个query是这么写的：
```go
q.Filter(sqlchemy.OR(sqlchemy.Equals(q.Field("id"), self.SecgrpId),sqlchemy.In(q.Field("id"), secQuery.Filed("guest_id"))))
```
新的写法
```go
q.OR(q.Equals("id", self.SecgrpId), q.In("id", secQuery.Filed("guest_id")))
```