### PR TITLE
fix: mark query.Count as deprecated

### DIFF
--- a/query.go
+++ b/query.go
@@ -398,6 +398,7 @@ func (tq *SQuery) Rows() (*sql.Rows, error) {
 	return _db.Query(sqlstr, vars...)
 }
 
+// deprecated
 func (tq *SQuery) Count() int {
 	cnt, _ := tq.CountWithError()
 	return cnt


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
mark query.Count as deprecated