### PR TITLE
query: 改正Count调用

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,30 @@
+package sqlchemy
+
+import (
+	"testing"
+)
+
+type testQueryTable struct {
+	Col0 string
+	Col1 int
+}
+
+var (
+	testTableSpec = NewTableSpecFromStruct(testQueryTable{}, "test")
+	testTable     = testTableSpec.Instance()
+)
+
+func testReset() {
+	tableIDLock.Lock()
+	defer tableIDLock.Unlock()
+
+	// next alias index must be 2 because 1 has already been taken by
+	// testTable
+	tableID = 1
+}
+
+func testGotWant(t *testing.T, got, want string) {
+	if got != want {
+		t.Fatalf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}

--- a/query.go
+++ b/query.go
@@ -457,21 +457,28 @@ func (tq *SQuery) Count() int {
 	return cnt
 }
 
+func (tq *SQuery) countQuery() *SQuery {
+	tq2 := *tq
+	tq2.limit = 0
+	tq2.offset = 0
+	cq := &SQuery{
+		fields: []IQueryField{
+			COUNT("count"),
+		},
+		from: tq2.SubQuery(),
+	}
+	return cq
+}
+
 func (tq *SQuery) CountWithError() (int, error) {
-	cq := SQuery{fields: []IQueryField{COUNT("count")},
-		from:    tq.from,
-		joins:   tq.joins,
-		where:   tq.where,
-		groupBy: tq.groupBy,
-		having:  tq.having}
-	var count int = 0
+	cq := tq.countQuery()
+	count := 0
 	err := cq.Row().Scan(&count)
-	if err != nil {
-		log.Errorf("SQuery count %s failed: %s", cq.String(), err)
-		return -1, err
-	} else {
+	if err == nil {
 		return count, nil
 	}
+	log.Errorf("SQuery count %s failed: %s", cq.String(), err)
+	return -1, err
 }
 
 func (tq *SQuery) Field(name string) IQueryField {

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,40 @@
+package sqlchemy
+
+import (
+	"testing"
+)
+
+func TestQuery(t *testing.T) {
+	t.Run("query all fields", func(t *testing.T) {
+		testReset()
+		q := testTable.Query()
+		want := "SELECT t1.col0, t1.col1 FROM `test` AS `t1`"
+		testGotWant(t, q.String(), want)
+	})
+
+	t.Run("query selected fields", func(t *testing.T) {
+		testReset()
+		q := testTable.Query(testTable.Field("col0")).Equals("col1", 100)
+		want := "SELECT t1.col0 FROM `test` AS `t1` WHERE `t1`.`col1` = ( ? )"
+		testGotWant(t, q.String(), want)
+	})
+
+	t.Run("query selected fields from subquery", func(t *testing.T) {
+		testReset()
+		q := testTable.Query().SubQuery().Query(testTable.Field("col0")).Equals("col1", 100)
+		want := "SELECT t1.col0 FROM (SELECT t1.col1 FROM `test` AS `t1`) AS `t2` WHERE `t2`.`col1` = ( ? )"
+		testGotWant(t, q.String(), want)
+	})
+}
+
+func TestCountQuery(t *testing.T) {
+	testReset()
+
+	q := testTable.Query()
+	q.GroupBy("col0")
+	q.Limit(8)
+	q.Offset(10)
+	cq := q.countQuery()
+	want := "SELECT COUNT(*) AS `count` FROM (SELECT t1.col0, t1.col1 FROM `test` AS `t1` GROUP BY `t1`.`col0`) AS `t2`"
+	testGotWant(t, cq.String(), want)
+}


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

当查询中有GROUP BY语句时，当前的Count实现不能表达出整体SQuery的结果数

需要更新依赖方的vendor

/cc @swordqiu 
/cc @bistuzx 