### PR TITLE
query: log not found fields only when DEBUG_SQLCHEMY

### DIFF
--- a/query.go
+++ b/query.go
@@ -483,8 +483,8 @@ func (tq *SQuery) CountWithError() (int, error) {
 
 func (tq *SQuery) Field(name string) IQueryField {
 	f := tq.findField(name)
-	if f == nil {
-		log.Errorf("cannot find field %s for query", name)
+	if DEBUG_SQLCHEMY && f == nil {
+		log.Debugf("cannot find field %s for query", name)
 	}
 	return f
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

query: log not found fields only when DEBUG_SQLCHEMY


/cc @yunionio/maintainer 