### PR TITLE
fix: allow text primary key with empty string

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -122,6 +122,10 @@ func (t *STableSpec) insertSqlPrep(dataFields reflectutils.SStructFieldValueSet,
 					panic(fmt.Sprintf("multiple auto_increment columns: %q, %q", autoIncField, k))
 				}
 				autoIncField = k
+			} else if c.IsText() {
+				values = append(values, "")
+				names = append(names, fmt.Sprintf("`%s`", k))
+				format = append(format, "?")
 			} else {
 				return "", nil, fmt.Errorf("cannot insert for null primary key %q", k)
 			}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
允许字符类型的primary key可以是空字符串