### PR TITLE
fix: update no rows returnes sql.ErrNoRows

### DIFF
--- a/update.go
+++ b/update.go
@@ -16,6 +16,7 @@ package sqlchemy
 
 import (
 	"bytes"
+	"database/sql"
 	"fmt"
 	"reflect"
 	"strings"
@@ -191,7 +192,11 @@ func (us *SUpdateSession) saveUpdate(dt interface{}) (UpdateDiffs, error) {
 		return nil, err
 	}
 	if aCnt != 1 {
-		return nil, fmt.Errorf("affected rows %d != 1", aCnt)
+		if aCnt == 0 {
+			return nil, sql.ErrNoRows
+		} else {
+			return nil, fmt.Errorf("affected rows %d != 1", aCnt)
+		}
 	}
 	q := us.tableSpec.Query()
 	for k, v := range primaries {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
当update没有更新row时，返回sql.ErrNoRows