### PR TITLE
feature: add new tag allow_zero, whichi allow insert or update zero value

### DIFF
--- a/column.go
+++ b/column.go
@@ -48,6 +48,7 @@ type IColumnSpec interface {
 	ConvertFromValue(val interface{}) interface{}
 	// ConvertToValue(str interface{}) interface{}
 	IsZero(val interface{}) bool
+	AllowZero() bool
 	// IsEqual(v1, v2 interface{}) bool
 	Tags() map[string]string
 
@@ -64,6 +65,7 @@ type SBaseColumn struct {
 	isPrimary     bool
 	isUnique      bool
 	isIndex       bool
+	isAllowZero   bool
 	tags          map[string]string
 }
 
@@ -125,6 +127,10 @@ func (c *SBaseColumn) IsSearchable() bool {
 
 func (c *SBaseColumn) IsNumeric() bool {
 	return false
+}
+
+func (c *SBaseColumn) AllowZero() bool {
+	return c.isAllowZero
 }
 
 func (c *SBaseColumn) ConvertFromString(str string) string {
@@ -217,6 +223,11 @@ func NewBaseColumn(name string, sqltype string, tagmap map[string]string, isPoin
 	if isPrimary {
 		isNullable = false
 	}
+	isAllowZero := false
+	tagmap, val, ok = utils.TagPop(tagmap, TAG_ALLOW_ZERO)
+	if ok {
+		isAllowZero = utils.ToBool(val)
+	}
 	return SBaseColumn{
 		name:          name,
 		dbName:        dbName,
@@ -228,6 +239,7 @@ func NewBaseColumn(name string, sqltype string, tagmap map[string]string, isPoin
 		isIndex:       isIndex,
 		tags:          tagmap,
 		isPointer:     isPointer,
+		isAllowZero:   isAllowZero,
 	}
 }
 

--- a/const.go
+++ b/const.go
@@ -46,4 +46,5 @@ const (
 	TAG_AUTOVERSION      = "auto_version"
 	TAG_UPDATE_TIMESTAMP = "updated_at"
 	TAG_CREATE_TIMESTAMP = "created_at"
+	TAG_ALLOW_ZERO       = "allow_zero"
 )

--- a/insert.go
+++ b/insert.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/util/reflectutils"
-	"yunion.io/x/pkg/errors"
 )
 
 func (t *STableSpec) Insert(dt interface{}) error {
@@ -92,7 +92,7 @@ func (t *STableSpec) insertSqlPrep(dataFields reflectutils.SStructFieldValueSet,
 		}
 
 		_, isTextCol := c.(*STextColumn)
-		if c.IsSupportDefault() && (len(c.Default()) > 0 || isTextCol) && !gotypes.IsNil(ov) && c.IsZero(ov) { // empty text value
+		if c.IsSupportDefault() && (len(c.Default()) > 0 || isTextCol) && !gotypes.IsNil(ov) && c.IsZero(ov) && !c.AllowZero() { // empty text value
 			val := c.ConvertFromString(c.Default())
 			values = append(values, val)
 			names = append(names, fmt.Sprintf("`%s`", k))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
增加一个allow_zero的列tag，表示该列在insert/insert_or_update时候，允许插入zero值。例如，一个column为数字，default为-1。alllow_zero=true, 则允许插入一个0值。如果allow_zero=false，则该列无法插入0值（因为0为zero，insert认为该列未初始化，所以不插入）。

/cc @yousong @zexi @wanyaoqi @rainzm 