### PR TITLE
fix: drop no-nullable attributes for no-default deleted columns

### DIFF
--- a/column.go
+++ b/column.go
@@ -34,6 +34,7 @@ type IColumnSpec interface {
 	Default() string
 	IsSupportDefault() bool
 	IsNullable() bool
+	SetNullable(on bool)
 	IsPrimary() bool
 	IsUnique() bool
 	IsIndex() bool
@@ -95,6 +96,10 @@ func (c *SBaseColumn) IsSupportDefault() bool {
 
 func (c *SBaseColumn) IsNullable() bool {
 	return c.isNullable
+}
+
+func (c *SBaseColumn) SetNullable(on bool) {
+	c.isNullable = on
 }
 
 func (c *SBaseColumn) IsPrimary() bool {

--- a/sync.go
+++ b/sync.go
@@ -336,6 +336,15 @@ func (ts *STableSpec) SyncSQL() []string {
 	for _, col := range remove {
 		sql := fmt.Sprintf("DROP COLUMN `%s`", col.Name())
 		// alters = append(alters, sql)
+		// ignore drop statement
+		// but if the column is not nullable but no default
+		// then need to drop the not-nullable attribute
+		if !col.IsNullable() && col.Default() == "" {
+			col.SetNullable(true)
+			sql := fmt.Sprintf("MODIFY %s", col.DefinitionString())
+			alters = append(alters, sql)
+			log.Errorf("column %s is not nullable but no default, drop not nullable attribute", col.Name())
+		}
 		log.Infof("ALTER TABLE %s %s;", ts.name, sql)
 	}
 	for _, cols := range update {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：目前默认保留remove的column，但是一些column是no-nullable并且无default，在给这样的表插入数据时，Maraiadb 10.3会报错。因此需要把这些column的no-nullable属性去掉。

/cc @yousong @zexi @wanyaoqi 