### PR TITLE
feature: add query snapshot feature, so as to know whether the query is altered

### DIFF
--- a/table.go
+++ b/table.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strings"
 
+	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 )
 
@@ -119,7 +120,8 @@ func (tbl *STable) Field(name string, alias ...string) IQueryField {
 	name = utils.CamelSplit(name, "_")
 	spec := tbl.spec.ColumnSpec(name)
 	if spec == nil {
-		panic("column not found: " + name)
+		log.Warningf("column %s not found in table %s", name, tbl.spec.Name())
+		return nil
 	}
 	col := STableField{table: tbl, spec: spec}
 	if len(alias) > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
为query增加了Snapshot和IsAltered两个方法，用来判断一个query是否在子函数中被改变

使用示例：

    netQ := NetworkManager.Query("id").Snapshot()
    netQ, err := manager.SWireResourceBaseManager.ListItemFilter(ctx, netQ, userCred, query.WireFilterListInput)
    if err != nil {
        return nil, errors.Wrap(err, "SWireResourceBaseManager.ListItemFilter")
    }
    if netQ.IsAltered() {
        q = q.Filter(sqlchemy.In(q.Field("network_id"), netQ.SubQuery()))
    }
