### PR TITLE
fix: Convert primary column's value when saveUpdate

### DIFF
--- a/update.go
+++ b/update.go
@@ -105,19 +105,13 @@ func (us *SUpdateSession) saveUpdate(dt interface{}) (UpdateDiffs, error) {
 		nf, _ := fields.GetInterface(k)
 		if c.IsPrimary() {
 			if !gotypes.IsNil(of) && !c.IsZero(of) {
-				primaries[k] = of
+				primaries[k] = c.ConvertFromValue(of)
 			} else if c.IsText() {
 				primaries[k] = ""
 			} else {
 				return nil, ErrEmptyPrimaryKey
 			}
 			continue
-		}
-		if !gotypes.IsNil(of) {
-			if c.IsPrimary() && !c.IsZero(of) { // skip update primary key
-				primaries[k] = of
-				continue
-			}
 		}
 		nc, ok := c.(*SIntegerColumn)
 		if ok && nc.IsAutoVersion {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 删除的代码块：

   ```go
   if !gotypes.IsNil(of) {
       if c.IsPrimary() && !c.IsZero(of) { // skip update primary key
           primaries[k] = of
           continue
       }
   }
   ```

   与上面的代码块：

   ```go
   if c.IsPrimary() {
       if !gotypes.IsNil(of) && !c.IsZero(of) {
           primaries[k] = of
       } else if c.IsText() {
           primaries[k] = ""
       } else {
           return nil, ErrEmptyPrimaryKey
       }
       continue
   }
   ```

   的第一处 if 的逻辑重复了，并且删除的代码块是不会执行的。

2. primaries 里面的 value 会作为 where 的判断，并且在下面的
     ```go
     q := us.tableSpec.Query()
     for k, v := range primaries {
         q = q.Equals(k, v)
     }
     err = q.First(dt)
     if err != nil {
         return nil, errors.Wrap(err, "query after update failed")
     }
     ```
     也用到了，所以 value 需要做一层 column.ConvertFromValue 的转换。
