### PR TITLE
fix: mysql utf8 should use utf8mb4:

### DIFF
--- a/column.go
+++ b/column.go
@@ -569,7 +569,17 @@ func (c *STextColumn) IsSupportDefault() bool {
 }
 
 func (c *STextColumn) ColType() string {
-	return fmt.Sprintf("%s CHARACTER SET '%s'", c.SBaseWidthColumn.ColType(), c.Charset)
+	var charset string
+	var collate string
+	switch c.Charset {
+	case "ascii":
+		charset = "ascii"
+		collate = "ascii_general_ci"
+	default:
+		charset = "utf8mb4"
+		collate = "utf8mb4_unicode_ci"
+	}
+	return fmt.Sprintf("%s CHARACTER SET '%s' COLLATE '%s'", c.SBaseWidthColumn.ColType(), charset, collate)
 }
 
 func (c *STextColumn) IsText() bool {

--- a/sync.go
+++ b/sync.go
@@ -74,8 +74,10 @@ func (info *SSqlColumnInfo) toColumnSpec() IColumnSpec {
 	charset := ""
 	if info.Collation == "ascii_general_ci" {
 		charset = "ascii"
-	} else if info.Collation == "utf8_general_ci" {
+	} else if info.Collation == "utf8_general_ci" || info.Collation == "utf8mb4_unicode_ci" {
 		charset = "utf8"
+	} else {
+		charset = "ascii"
 	}
 	if len(charset) > 0 {
 		tagmap[TAG_CHARSET] = charset

--- a/table.go
+++ b/table.go
@@ -102,7 +102,7 @@ func (ts *STableSpec) CreateSQL() string {
 	if len(indexes) > 0 {
 		cols = append(cols, indexes...)
 	}
-	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s` (\n%s\n) ENGINE=InnoDB DEFAULT CHARSET=utf8%s", ts.name, strings.Join(cols, ",\n"), autoInc)
+	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s` (\n%s\n) ENGINE=InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci%s", ts.name, strings.Join(cols, ",\n"), autoInc)
 }
 
 func (ts *STableSpec) Instance() *STable {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

mysql utf8使用utf8mb4。参考 https://mathiasbynens.be/notes/mysql-utf8mb4#utf8-to-utf8mb4.
因为转为utf8mb4，导致ut8 varchar primary key的最大长度不能超过191（因为最大primary key byte长度为767, 767/4=191）。所以这个修改之后，长度超过191的相应的mysql model的utf8 primary varchar定义需要修改。

/cc @zexi @yousong 