### PR TITLE
fix: make sure the order of fields in SSubQuery

### DIFF
--- a/query.go
+++ b/query.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"yunion.io/x/log"
@@ -153,6 +154,10 @@ func (sq *SSubQuery) Expression() string {
 	for k := range sq.referedFields {
 		fields = append(fields, sq.referedFields[k])
 	}
+	// Make sure the order of the fields
+	sort.Slice(fields, func(i, j int) bool {
+		return fields[i].Name() < fields[j].Name()
+	})
 	return fmt.Sprintf("(%s)", sq.query.String(fields...))
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

This is to ensure that the results of multiple calls to SSubQuery.Expression
must be the same without changing SSubQuery.

And SQuery.Snapshot and SQuery.Altered() can work fine.
