### PR TITLE
fix: 1. backend-specific union operator 2. splitable index

### DIFF
--- a/backends.go
+++ b/backends.go
@@ -55,6 +55,10 @@ type IBackend interface {
 	CurrentTimeStampString() string
 	//
 	CaseInsensitiveLikeString() string
+	//
+	UnionAllString() string
+	//
+	UnionDistinctString() string
 
 	// Capability
 

--- a/backends/clickhouse/clickhouse.go
+++ b/backends/clickhouse/clickhouse.go
@@ -76,6 +76,14 @@ func (click *SClickhouseBackend) CurrentTimeStampString() string {
 	return "NOW()"
 }
 
+func (click *SClickhouseBackend) UnionAllString() string {
+	return "UNION ALL"
+}
+
+func (click *SClickhouseBackend) UnionDistinctString() string {
+	return "UNION DISTINCT"
+}
+
 func (click *SClickhouseBackend) UpdateSQLTemplate() string {
 	return "ALTER TABLE `{{ .Table }}` UPDATE {{ .Columns }} WHERE {{ .Conditions }}"
 }

--- a/backends/mysql/mysql.go
+++ b/backends/mysql/mysql.go
@@ -124,7 +124,7 @@ func (mysql *SMySQLBackend) FetchIndexesAndConstraints(ts sqlchemy.ITableSpec) (
 		}
 		return nil, nil, err
 	}
-	indexes := parseIndexes(defStr)
+	indexes := parseIndexes(ts, defStr)
 	constraints := parseConstraints(defStr)
 	return indexes, constraints, nil
 }

--- a/backends/mysql/parse.go
+++ b/backends/mysql/parse.go
@@ -48,12 +48,12 @@ func parseConstraints(defStr string) []sqlchemy.STableConstraint {
 	return tcs
 }
 
-func parseIndexes(defStr string) []sqlchemy.STableIndex {
+func parseIndexes(ts sqlchemy.ITableSpec, defStr string) []sqlchemy.STableIndex {
 	matches := indexRegexp.FindAllStringSubmatch(defStr, -1)
 	tcs := make([]sqlchemy.STableIndex, len(matches))
 	for i := range matches {
 		tcs[i] = sqlchemy.NewTableIndex(
-			matches[i][2],
+			ts,
 			fetchColumns(matches[i][3]),
 			len(matches[i][1]) > 0,
 		)

--- a/backends/mysql/parse_test.go
+++ b/backends/mysql/parse_test.go
@@ -43,7 +43,7 @@ func TestParseCreateTable(t *testing.T) {
 	if len(cons) != 1 {
 		t.Errorf("fail to find constraints")
 	}
-	idxs := parseIndexes(tableDef)
+	idxs := parseIndexes(nil, tableDef)
 	if len(idxs) != 4 {
 		t.Errorf("fail to find indexes")
 	}

--- a/backends/mysql/query_test.go
+++ b/backends/mysql/query_test.go
@@ -48,7 +48,7 @@ func TestQuery(t *testing.T) {
 		q2 := testTable.Query(testTable.Field("col0")).Equals("col1", 200)
 		uq := sqlchemy.Union(q1, q2)
 		q := uq.Query()
-		want := "SELECT `t2`.`col0` FROM (SELECT `t3`.`col0` FROM (SELECT `t1`.`col0` FROM `test` AS `t1` WHERE `t1`.`col1` = ( ? )) AS `t3` UNION DISTINCT SELECT `t4`.`col0` FROM (SELECT `t1`.`col0` FROM `test` AS `t1` WHERE `t1`.`col1` = ( ? )) AS `t4`) AS `t2`"
+		want := "SELECT `t2`.`col0` FROM (SELECT `t3`.`col0` FROM (SELECT `t1`.`col0` FROM `test` AS `t1` WHERE `t1`.`col1` = ( ? )) AS `t3` UNION SELECT `t4`.`col0` FROM (SELECT `t1`.`col0` FROM `test` AS `t1` WHERE `t1`.`col1` = ( ? )) AS `t4`) AS `t2`"
 		testGotWant(t, q.String(), want)
 	})
 

--- a/backends/sqlite/parse.go
+++ b/backends/sqlite/parse.go
@@ -36,10 +36,10 @@ type sSqliteTableInfo struct {
 	Sql  string
 }
 
-func (ti *sSqliteTableInfo) parseTableIndex() (sqlchemy.STableIndex, error) {
+func (ti *sSqliteTableInfo) parseTableIndex(ts sqlchemy.ITableSpec) (sqlchemy.STableIndex, error) {
 	matches := indexRegexp.FindAllStringSubmatch(ti.Sql, -1)
 	if len(matches) > 0 {
-		return sqlchemy.NewTableIndex(ti.Name, sqlchemy.FetchColumns(matches[0][1]), false), nil
+		return sqlchemy.NewTableIndex(ts, sqlchemy.FetchColumns(matches[0][1]), false), nil
 	}
 	return sqlchemy.STableIndex{}, errors.ErrNotFound
 }

--- a/backends/sqlite/parse_test.go
+++ b/backends/sqlite/parse_test.go
@@ -22,7 +22,7 @@ func TestParseTableIndex(t *testing.T) {
 			Name: "index",
 			Sql:  c.in,
 		}
-		index, err := ti.parseTableIndex()
+		index, err := ti.parseTableIndex(nil)
 		if err != nil {
 			t.Errorf("parseTableIndex fail %s", err)
 		} else {

--- a/backends/sqlite/sqlite.go
+++ b/backends/sqlite/sqlite.go
@@ -111,7 +111,7 @@ func (sqlite *SSqliteBackend) FetchIndexesAndConstraints(ts sqlchemy.ITableSpec)
 	}
 	indexes := make([]sqlchemy.STableIndex, 0)
 	for i := range results {
-		ti, err := results[i].parseTableIndex()
+		ti, err := results[i].parseTableIndex(ts)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "parseTableIndex fail %s", results[i].Sql)
 		}

--- a/backends_base.go
+++ b/backends_base.go
@@ -60,6 +60,14 @@ func (bb *SBaseBackend) CaseInsensitiveLikeString() string {
 	return "LIKE"
 }
 
+func (bb *SBaseBackend) UnionAllString() string {
+	return "UNION ALL"
+}
+
+func (bb *SBaseBackend) UnionDistinctString() string {
+	return "UNION"
+}
+
 func (bb *SBaseBackend) CanUpdate() bool {
 	return false
 }

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -40,7 +40,7 @@ func TestFetchColumns(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := FetchColumns(c.in)
-		index := NewTableIndex("", c.want, false)
+		index := NewTableIndex(nil, c.want, false)
 		if !index.IsIdentical(got...) {
 			t.Errorf("want: %s got: %s", c.want, got)
 		}

--- a/index.go
+++ b/index.go
@@ -21,17 +21,20 @@ import (
 )
 
 type STableIndex struct {
-	name     string
+	// name     string
 	columns  []string
 	isUnique bool
+
+	ts ITableSpec
 }
 
-func NewTableIndex(name string, cols []string, unique bool) STableIndex {
+func NewTableIndex(ts ITableSpec, cols []string, unique bool) STableIndex {
 	sort.Sort(TColumnNames(cols))
 	return STableIndex{
-		name:     name,
+		// name:     name,
 		columns:  cols,
 		isUnique: unique,
+		ts:       ts,
 	}
 }
 
@@ -54,7 +57,13 @@ func (cols TColumnNames) Less(i, j int) bool {
 }
 
 func (index *STableIndex) Name() string {
-	return index.name
+	return fmt.Sprintf("ix_%s_%s", index.ts.Name(), strings.Join(index.columns, "_"))
+}
+
+func (index STableIndex) clone(ts ITableSpec) STableIndex {
+	cols := make([]string, len(index.columns))
+	copy(cols, index.columns)
+	return NewTableIndex(ts, cols, index.isUnique)
 }
 
 func (index *STableIndex) IsIdentical(cols ...string) bool {
@@ -86,8 +95,7 @@ func (ts *STableSpec) AddIndex(unique bool, cols ...string) bool {
 			return false
 		}
 	}
-	name := fmt.Sprintf("ix_%s_%s", ts.name, strings.Join(cols, "_"))
-	idx := STableIndex{name: name, columns: cols, isUnique: unique}
+	idx := STableIndex{columns: cols, isUnique: unique, ts: ts}
 	ts._indexes = append(ts._indexes, idx)
 	return true
 }

--- a/query_test.go
+++ b/query_test.go
@@ -88,7 +88,7 @@ func TestQueryString(t *testing.T) {
 				q3 := t.Query(t.Field("id")).In("name", uq.Query().SubQuery())
 				return q3
 			}(),
-			want: "SELECT `t9`.`id` FROM `testtable` AS `t9` WHERE `t9`.`name` IN (SELECT `t10`.`name` FROM (SELECT `t58`.`name` FROM (SELECT `t9`.`name` FROM `testtable` AS `t9` WHERE `t9`.`id` = ( ? )) AS `t58` UNION DISTINCT SELECT `t59`.`name` FROM (SELECT `t9`.`name` FROM `testtable` AS `t9` WHERE `t9`.`id` = ( ? )) AS `t59`) AS `t10`)",
+			want: "SELECT `t9`.`id` FROM `testtable` AS `t9` WHERE `t9`.`name` IN (SELECT `t10`.`name` FROM (SELECT `t58`.`name` FROM (SELECT `t9`.`name` FROM `testtable` AS `t9` WHERE `t9`.`id` = ( ? )) AS `t58` UNION SELECT `t59`.`name` FROM (SELECT `t9`.`name` FROM `testtable` AS `t9` WHERE `t9`.`id` = ( ? )) AS `t59`) AS `t10`)",
 			vars: 2,
 		},
 		{

--- a/sync_test.go
+++ b/sync_test.go
@@ -95,24 +95,24 @@ func TestDiffIndex(t *testing.T) {
 	}{
 		{
 			index1: []STableIndex{
-				NewTableIndex("ix_table_name", []string{"name"}, false),
+				NewTableIndex(nil, []string{"name"}, false),
 			},
 			index2: []STableIndex{
-				NewTableIndex("ix_table_name", []string{"name", "age"}, false),
+				NewTableIndex(nil, []string{"name", "age"}, false),
 			},
 			remove: []STableIndex{
-				NewTableIndex("ix_table_name", []string{"name"}, false),
+				NewTableIndex(nil, []string{"name"}, false),
 			},
 			add: []STableIndex{
-				NewTableIndex("ix_table_name", []string{"name", "age"}, false),
+				NewTableIndex(nil, []string{"name", "age"}, false),
 			},
 		},
 		{
 			index1: []STableIndex{
-				NewTableIndex("ix_table_name", []string{"name"}, false),
+				NewTableIndex(nil, []string{"name"}, false),
 			},
 			index2: []STableIndex{
-				NewTableIndex("ix_table_name", []string{"name"}, false),
+				NewTableIndex(nil, []string{"name"}, false),
 			},
 			remove: []STableIndex{},
 			add:    []STableIndex{},

--- a/table.go
+++ b/table.go
@@ -152,14 +152,19 @@ func (ts *STableSpec) Clone(name string, autoIncOffset int64) *STableSpec {
 			newCols[i] = col
 		}
 	}
-	return &STableSpec{
+	nts := &STableSpec{
 		structType:  ts.structType,
 		name:        name,
 		_columns:    newCols,
-		_indexes:    ts._indexes,
 		_contraints: ts._contraints,
 		sDBReferer:  ts.sDBReferer,
 	}
+	newIndexes := make([]STableIndex, len(ts._indexes))
+	for i := range ts._indexes {
+		newIndexes[i] = ts._indexes[i].clone(nts)
+	}
+	nts._indexes = newIndexes
+	return nts
 }
 
 // Columns implementation of STableSpec for ITableSpec

--- a/union.go
+++ b/union.go
@@ -87,9 +87,9 @@ func (uq *SUnion) Alias() string {
 
 func (uq *SUnion) operator() string {
 	if uq.isAll {
-		return " UNION ALL "
+		return uq.database().backend.UnionAllString()
 	} else {
-		return " UNION DISTINCT "
+		return uq.database().backend.UnionDistinctString()
 	}
 }
 
@@ -99,7 +99,9 @@ func (uq *SUnion) Expression() string {
 	buf.WriteString("(")
 	for i := range uq.queries {
 		if i != 0 {
+			buf.WriteByte(' ')
 			buf.WriteString(uq.operator())
+			buf.WriteByte(' ')
 		}
 		subQ := uq.queries[i].SubQuery()
 		buf.WriteString(subQ.Query().String())


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. Union需要跟backend相关 2. splitable的子表的索引名字重复
