### PR TITLE
fix: clickhouse order by must be prefixed with primary keys

### DIFF
--- a/backends/clickhouse/clickhouse.go
+++ b/backends/clickhouse/clickhouse.go
@@ -117,16 +117,24 @@ func (click *SClickhouseBackend) GetCreateSQLs(ts sqlchemy.ITableSpec) []string 
 	if len(orderbys) == 0 {
 		orderbys = primaries
 	}
-	if len(orderbys) > 0 {
-		createSql += fmt.Sprintf("\nORDER BY (%s)", strings.Join(orderbys, ", "))
-	} else {
-		createSql += fmt.Sprintf("\nORDER BY tuple()")
-	}
 	if len(partitions) > 0 {
 		createSql += fmt.Sprintf("\nPARTITION BY (%s)", strings.Join(partitions, ", "))
 	}
 	if len(primaries) > 0 {
 		createSql += fmt.Sprintf("\nPRIMARY KEY (%s)", strings.Join(primaries, ", "))
+		newOrderBys := make([]string, len(primaries))
+		copy(newOrderBys, primaries)
+		for _, f := range orderbys {
+			if !utils.IsInStringArray(f, newOrderBys) {
+				newOrderBys = append(newOrderBys, f)
+			}
+		}
+		orderbys = newOrderBys
+	}
+	if len(orderbys) > 0 {
+		createSql += fmt.Sprintf("\nORDER BY (%s)", strings.Join(orderbys, ", "))
+	} else {
+		createSql += fmt.Sprintf("\nORDER BY tuple()")
 	}
 	if ttlCol != nil {
 		ttlCount, ttlUnit := ttlCol.GetTTL()

--- a/backends/clickhouse/column.go
+++ b/backends/clickhouse/column.go
@@ -125,9 +125,6 @@ func (c *SClickhouseBaseColumn) SetTTL(int, string) {
 }
 
 func NewClickhouseBaseColumn(name string, sqltype string, tagmap map[string]string, isPointer bool) SClickhouseBaseColumn {
-	// clickhouse not support primary key
-	tagmap, _, _ = utils.TagPop(tagmap, sqlchemy.TAG_PRIMARY)
-
 	var ok bool
 	var val string
 	partition := ""


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: clickhouse order by must be prefixed with primary keys