### PR TITLE
fix: clickhouse argument count error

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -42,7 +42,7 @@ func getQuoteStringValue(dat interface{}) string {
 }
 
 func GetStringValue(dat interface{}) string {
-	value := reflect.ValueOf(dat)
+	value := reflect.Indirect(reflect.ValueOf(dat))
 	switch value.Type() {
 	case tristate.TriStateType:
 		return dat.(tristate.TriState).String()

--- a/sql.go
+++ b/sql.go
@@ -184,11 +184,7 @@ func (db *SDatabase) TxBatchExec(sqlstr string, varsList [][]interface{}) ([]SSq
 }
 
 func (db *SDatabase) TxExec(sqlstr string, vars ...interface{}) (sql.Result, error) {
-	results, err := db.TxBatchExec(sqlstr, [][]interface{}{vars})
-	if err != nil {
-		return nil, errors.Wrap(err, "TxBatchExec")
-	}
-	return results[0].Result, results[0].Error
+	return db.db.Exec(sqlstr, vars...)
 }
 
 func (db *SDatabase) DB() *sql.DB {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
 修正：clickhouse参数不准的错误，规避clickhouse-go的bug

INSERT INTO `tags_tbl` (`account_id`, `batch_id`, `created_at`, `day`, `deleted`, `id`, `key`, `mark`, `resource_id`, `resource_project_id`, `update_version`, `updated_at`, `value`) VALUES (?, ?, NOW('UTC'), ?, ?, ?, ?, ?, ?, ?, ?, NOW('UTC'), ?)
values: []interface {}{"", "", 0, 0x0, "a6a46d60-fa5e-41f8-88df-44f931e63d22", "user:Owner", "", "c99aaf82-4b40-497d-83ca-f2695d46af2c", "", 0, "zeno"}
[Append]: expected 13 arguments, got 11