### PR TITLE
fix: clickhouse datetime column specify utc timezone by default

### DIFF
--- a/backends/clickhouse/clickhouse.go
+++ b/backends/clickhouse/clickhouse.go
@@ -141,7 +141,6 @@ func (click *SClickhouseBackend) GetCreateSQLs(ts sqlchemy.ITableSpec) []string 
 		createSql += fmt.Sprintf("\nTTL `%s` + INTERVAL %d %s", ttlCol.Name(), ttlCount, ttlUnit)
 	}
 	// set default time zone of table to UTC
-	createSql += "\nDateTime('UTC')"
 	createSql += "\nSETTINGS index_granularity=8192"
 	return []string{
 		createSql,

--- a/backends/clickhouse/column.go
+++ b/backends/clickhouse/column.go
@@ -633,7 +633,7 @@ func NewDateTimeColumn(name string, tagmap map[string]string, isPointer bool) SD
 		updatedAt = utils.ToBool(v)
 	}
 	dtc := SDateTimeColumn{
-		STimeTypeColumn: NewTimeTypeColumn(name, "DateTime", tagmap, isPointer),
+		STimeTypeColumn: NewTimeTypeColumn(name, "DateTime('UTC')", tagmap, isPointer),
 		isCreatedAt:     createdAt,
 		isUpdatedAt:     updatedAt,
 	}

--- a/backends/clickhouse/column_test.go
+++ b/backends/clickhouse/column_test.go
@@ -155,15 +155,15 @@ func TestColumns(t *testing.T) {
 		},
 		{
 			in:   &dateCol,
-			want: "`field` Nullable(DateTime)",
+			want: "`field` Nullable(DateTime('UTC'))",
 		},
 		{
 			in:   &ttlDateCol,
-			want: "`field` Nullable(DateTime)",
+			want: "`field` Nullable(DateTime('UTC'))",
 		},
 		{
 			in:   &notNullDateCol,
-			want: "`field` DateTime",
+			want: "`field` DateTime('UTC')",
 		},
 		{
 			in:   &compCol,

--- a/backends/clickhouse/columninfo.go
+++ b/backends/clickhouse/columninfo.go
@@ -97,7 +97,7 @@ func (info *sSqlColumnInfo) toColumnSpec() sqlchemy.IColumnSpec {
 	case "Float32", "Float64":
 		c := NewFloatColumn(info.Name, sqlType, info.getTagmap(), false)
 		return &c
-	case "DateTime":
+	case "DateTime", "DateTime('UTC')":
 		c := NewDateTimeColumn(info.Name, info.getTagmap(), false)
 		return &c
 	default:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module yunion.io/x/sqlchemy
 
-go 1.16
+go 1.17
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.1.0
@@ -11,6 +11,28 @@ require (
 	yunion.io/x/jsonutils v0.0.0-20220106020632-953b71a4c3a8
 	yunion.io/x/log v1.0.0
 	yunion.io/x/pkg v1.0.0
+)
+
+require (
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/golang-plus/errors v1.0.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/paulmach/orb v0.7.1 // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
+	go.opentelemetry.io/otel v1.7.0 // indirect
+	go.opentelemetry.io/otel/trace v1.7.0 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/sys v0.0.0-20220429233432-b5fbb4746d32 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 replace github.com/go-logr/logr => github.com/go-logr/logr v0.4.0


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
clickhouse datetime column specify utc timezone by default