### PR TITLE
fix: dameng timestamp default precision zero

### DIFF
--- a/backends/dameng/column.go
+++ b/backends/dameng/column.go
@@ -505,12 +505,12 @@ func (c *STimeTypeColumn) ConvertFromString(str string) interface{} {
 // NewTimeTypeColumn return an instance of STimeTypeColumn
 func NewTimeTypeColumn(name string, typeStr string, tagmap map[string]string, isPointer bool) STimeTypeColumn {
 	tagmap, v, ok := utils.TagPop(tagmap, sqlchemy.TAG_PRECISION)
-	prec := 6
+	prec := 0
 	if ok {
 		prec, _ = strconv.Atoi(v)
-		if prec > 6 || prec <= 0 {
+		if prec > 6 || prec < 0 {
 			log.Warningf("datetime field %s precision %d change to 6", name, prec)
-			prec = 6
+			prec = 0
 		}
 	}
 	dc := STimeTypeColumn{

--- a/backends/dameng/column_test.go
+++ b/backends/dameng/column_test.go
@@ -106,11 +106,11 @@ func TestColumns(t *testing.T) {
 		},
 		{
 			in:   &dateCol,
-			want: `"field" TIMESTAMP(6)`,
+			want: `"field" TIMESTAMP(0)`,
 		},
 		{
 			in:   &notNullDateCol,
-			want: `"field" TIMESTAMP(6) NOT NULL`,
+			want: `"field" TIMESTAMP(0) NOT NULL`,
 		},
 		{
 			in:   &compCol,


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: dameng timestamp default precision zero