### PR TITLE
fix: truncate string variables for varchar fields

### DIFF
--- a/column.go
+++ b/column.go
@@ -72,6 +72,8 @@ type IColumnSpec interface {
 	// IsNumeric returns whether this column is a numeric type column, e.g. integer or float
 	IsNumeric() bool
 
+	GetWidth() int
+
 	// ConvertFromString returns the SQL representation of a value in string format for this column
 	ConvertFromString(str string) interface{}
 
@@ -304,6 +306,10 @@ func (c *SBaseColumn) SetColIndex(idx int) {
 	c.colIndex = idx
 }
 
+func (c *SBaseColumn) GetWidth() int {
+	return 0
+}
+
 // NewBaseColumn returns an instance of SBaseColumn
 func NewBaseColumn(name string, sqltype string, tagmap map[string]string, isPointer bool) SBaseColumn {
 	var val string
@@ -380,6 +386,10 @@ func (c *SBaseWidthColumn) ColType() string {
 		return fmt.Sprintf("%s(%d)", c.sqlType, c.width)
 	}
 	return c.sqlType
+}
+
+func (c *SBaseWidthColumn) GetWidth() int {
+	return c.width
 }
 
 // NewBaseWidthColumn return an instance of SBaseWidthColumn

--- a/insert.go
+++ b/insert.go
@@ -158,6 +158,13 @@ func (t *STableSpec) InsertSqlPrep(data interface{}, update bool) (*InsertSqlRes
 
 		// not empty
 		if !gotypes.IsNil(ov) && (!c.IsZero(ov) || (!c.IsPointer() && !c.IsText())) && !isAutoInc {
+			// validate text width
+			if c.IsString() && c.GetWidth() > 0 {
+				newStr, ok := ov.(string)
+				if ok && len(newStr) > c.GetWidth() {
+					ov = newStr[:c.GetWidth()]
+				}
+			}
 			v := c.ConvertFromValue(ov)
 			values = append(values, v)
 			names = append(names, fmt.Sprintf("%s%s%s", qChar, k, qChar))

--- a/insert_batch.go
+++ b/insert_batch.go
@@ -111,6 +111,13 @@ func (t *STableSpec) InsertBatch(dataList []interface{}) error {
 					params = append(params, nil)
 				}
 			} else {
+				// validate text width
+				if col.IsString() && col.GetWidth() > 0 {
+					newStr, ok := ov.(string)
+					if ok && len(newStr) > col.GetWidth() {
+						ov = newStr[:col.GetWidth()]
+					}
+				}
 				params = append(params, col.ConvertFromValue(ov))
 			}
 		}

--- a/update.go
+++ b/update.go
@@ -198,6 +198,13 @@ func (us *SUpdateSession) SaveUpdateSql(dt interface{}) (*SUpdateSQLResult, erro
 		if gotypes.IsNil(udif.new) {
 			colsets = append(colsets, fmt.Sprintf("%s%s%s = NULL", qChar, udif.col.Name(), qChar))
 		} else {
+			// validate text length
+			if udif.col.IsString() && udif.col.GetWidth() > 0 {
+				newStr, ok := udif.new.(string)
+				if ok && len(newStr) > udif.col.GetWidth() {
+					udif.new = newStr[:udif.col.GetWidth()]
+				}
+			}
 			colsets = append(colsets, fmt.Sprintf("%s%s%s = ?", qChar, udif.col.Name(), qChar))
 			vars = append(vars, udif.col.ConvertFromValue(udif.new))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: truncate string variables for varchar fields